### PR TITLE
(please verify) url regex update (read desc)

### DIFF
--- a/reader.py
+++ b/reader.py
@@ -61,7 +61,7 @@ def start_getting_files(extract_path: str, out_path: str):
         file = open(filename, "rb")
         header = file.read(92)
 
-        link = re.findall("https:\\/\\/[a-zA-Z0-9]*\\.rbxcdn\\.com\\/[a-z0-9]*", header.decode(errors="ignore"))
+        link = re.findall("https:\\/\\/[a-zA-Z0-9]{1,10}\\.rbxcdn\\.com\\/[a-f0-9]{32}", header.decode(errors="ignore"))
         file.close()
 
         if not link:


### PR DESCRIPTION
this is more just to make a better standard for cdn url searching. primary change is the end segment, instead of looking for a-z0-9 it looks for 32 characters of a-f0-9